### PR TITLE
Update build actions

### DIFF
--- a/.github/workflows/docker.build.composer-1.yaml
+++ b/.github/workflows/docker.build.composer-1.yaml
@@ -19,7 +19,7 @@ jobs:
         user: [ "composer", "root" ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: 'main'
           fetch-depth: 100
@@ -31,7 +31,7 @@ jobs:
       - run: |
           sudo chmod -R ugo+rwX . && shopt -s dotglob && rm -rf *
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ steps.latest_version.outputs.tag }}
           fetch-depth: 100
@@ -48,7 +48,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           flavor: |
             latest=false
@@ -68,12 +68,12 @@ jobs:
 
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       -
         name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1
@@ -82,7 +82,7 @@ jobs:
           password: ${{ secrets.DOCKER_IO_REGISTRY_PASSWORD }}
 
       - name: Login to Google Artifacts Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: europe-docker.pkg.dev/flownative/docker
           username: '_json_key'
@@ -97,7 +97,7 @@ jobs:
           echo "USER ${{ matrix.user }}" >> Dockerfile
 
       - name: Build Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker.build.composer-2.yaml
+++ b/.github/workflows/docker.build.composer-2.yaml
@@ -19,7 +19,7 @@ jobs:
         user: [ "composer", "root" ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: 'main'
           fetch-depth: 100
@@ -31,7 +31,7 @@ jobs:
       - run: |
           sudo chmod -R ugo+rwX . && shopt -s dotglob && rm -rf *
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ steps.latest_version.outputs.tag }}
           fetch-depth: 100
@@ -48,7 +48,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           flavor: |
             latest=false
@@ -68,21 +68,21 @@ jobs:
 
       - name: Set up QEMU
         id: qemu
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       -
         name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_IO_REGISTRY_USER }}
           password: ${{ secrets.DOCKER_IO_REGISTRY_PASSWORD }}
 
       - name: Login to Google Artifacts Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: europe-docker.pkg.dev/flownative/docker
           username: '_json_key'
@@ -97,7 +97,7 @@ jobs:
           echo "USER ${{ matrix.user }}" >> Dockerfile
 
       - name: Build Docker image
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
The changes in the releases updated to all are non-breaking.

Benefit is the use of Node v16, eliminating deprecation warnings.
